### PR TITLE
Changing the test for hasOwnProperty for a safer method

### DIFF
--- a/src/dotize.js
+++ b/src/dotize.js
@@ -59,7 +59,7 @@ dotize.convert = function(obj, prefix) {
 
     function isEmptyObj(obj) {
         for (var prop in obj) {
-            if (obj.hasOwnProperty(prop))
+            if (Object.hasOwnProperty.call(obj, prop))
                 return false;
         }
 


### PR DESCRIPTION
I encountered an error when I passed in an object automatically created by Restify. Apparently that object did not inherit from Object.prototype.
